### PR TITLE
redirect python installable location for VSCode

### DIFF
--- a/.vscode/python
+++ b/.vscode/python
@@ -1,0 +1,2 @@
+#!/bin/bash
+"$(dirname $0)/../.venv/bin/python" "$@"

--- a/.vscode/python.bat
+++ b/.vscode/python.bat
@@ -1,0 +1,2 @@
+@echo off
+"%~dp0/../.venv/Scripts/python.exe" %*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -185,6 +185,7 @@
   },
   "mypy-type-checker.importStrategy": "fromEnvironment",
   "python.terminal.activateEnvironment": true,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.vscode/python",
   // python.analysis is Pylance (pyright) configurations
   "python.analysis.fixAll": [
     // Explicitly omiting "source.convertImportFormat", let Ruff handle it


### PR DESCRIPTION
Attempted a solution to automatically get the uv .venv out of the box, but doesn't really work. I still get
<img width="479" height="192" alt="image" src="https://github.com/user-attachments/assets/49f848c3-1a4c-409b-9219-d19e6f005c9c" />

Idea from https://github.com/dprint/dprint/issues/859#issuecomment-3194102785

Real fix would probably come from https://github.com/microsoft/vscode/issues/5595